### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,7 +22,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-
+    @item = Item.find(params[:id])
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,9 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
 
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,7 @@
         <% @items.each do |item| %>
 
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -110,9 +110,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
+  <a href="#" class="another-item"><%= @item.item_category.name %>をもっと見る</a>
+  
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.fee_status.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.detail %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.item_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_sale_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,16 +24,24 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%# <% if user_signed_in? && @item.purchase_record == nil %> 
 
 
+        <% if user_signed_in? && current_user.id == @item.user_id %>
+
+              <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+              <p class="or-text">or</p>
+              <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+
+        <% else %>
+
+              <%# 商品が売れていない場合はこちらを表示しましょう %>
+              <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+              <%# //商品が売れていない場合はこちらを表示しましょう %>
+
+        <% end %>
+
+    <%# <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,9 +23,7 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %>
-
 
         <% if current_user.id == @item.user_id %>
 
@@ -42,8 +40,7 @@
         <% end %>
 
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+   
     <div class="item-explain-box">
       <span><%= @item.detail %></span>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <%# <% if user_signed_in? && @item.purchase_record == nil %> 
+    <% if user_signed_in? %>
 
 
         <% if user_signed_in? && current_user.id == @item.user_id %>
@@ -41,7 +41,7 @@
 
         <% end %>
 
-    <%# <% end %>
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? %>
 
 
-        <% if user_signed_in? && current_user.id == @item.user_id %>
+        <% if current_user.id == @item.user_id %>
 
               <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
               <p class="or-text">or</p>


### PR DESCRIPTION
# What
出品されている商品の詳細ページをみる機能を実装

# Why
商品に詳細ページへのリンクを貼って置き、ログインしていないユーザーであっても詳細ページを見ることができるようにする。それによりその商品に、より興味を持ってもらい、購入してもらうきっかけになる事が期待できる。ひいては、このフリマアプリを利用するユーザーを増やすためでもある。

＜Gyazoで撮影したもの＞　※購入機能は未実装です
・ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移
https://gyazo.com/41f9807ee29f7b8dee4d0b6f04d45c10

・ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移
https://gyazo.com/8fcbc2e201d6453739fabcb749adb683

・ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/3bc98e9b7c5a1f1ab803aebdb10edcd2
