### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,7 +40,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+    
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_top_page, only: [:edit, :update]
+  before_action :move_to_top_page, only: [:edit, :update, :destroy]
   before_action :define_item, only: [:show, :edit, :update, :destroy]
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :move_to_top_page, only: [:edit, :update]
-  before_action :define_item, only: [:show, :edit, :update]
+  before_action :define_item, only: [:show, :edit, :update, :destroy]
 
 
   def index
@@ -40,10 +40,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
     
+    @item.destroy
+    redirect_to root_path
+
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,6 +39,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+
+  end
+
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 
               <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
               <p class="or-text">or</p>
-              <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+              <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
         <% else %>
 


### PR DESCRIPTION
# What
１度出した商品を削除する機能を作る

# Why
出品者は時には、一度出した商品を無かったことにしたい場合がある。
そういう時に、商品を削除する機能が必要である。
これがないと、出品者に不利益を与えてしまう可能性があるので
この機能は必須機能であると思われる。

＜Gyazoで撮影したもの＞
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
①ユーザー「ken」がトップページ→オムライスの絵画ページへ
https://gyazo.com/c85ea47866afa571b02903f38f2ce24b

②削除を実行→トップページ→ページの商品一覧にオムライスの絵画が無いことを確認
https://gyazo.com/f346b0a16e9d9c012b2f9c6ba29ddaa2